### PR TITLE
feat: type custom field inserts

### DIFF
--- a/Latest TODO's for Jake
+++ b/Latest TODO's for Jake
@@ -1,3 +1,8 @@
+- [NEW] Regenerate Supabase types in `src/types/supabase.ts` with Supabase CLI output.
+  Steps:
+    1. Run `supabase gen types typescript --project-id <PROJECT_ID> --schema public > src/types/supabase.ts`.
+    2. Ensure the generated file stays updated with future schema changes.
+
 - [NEW] Replace alert for missing user in `src/pages/Customers.tsx` import confirmation handlers with a toast/snackbar component.
   Steps:
     1. Install a toast library (e.g., `react-toastify`).

--- a/src/pages/Customers.tsx
+++ b/src/pages/Customers.tsx
@@ -15,7 +15,9 @@ import {
   replaceCustomers,
   type Customer as SbcCustomer,
 } from "@/services/customerService";
-import { getFields, addField, type CustomField } from "@/services/fieldsService";
+import { getFields, type CustomField } from "@/services/fieldsService";
+import { supabase } from "@/utils/supabaseClient";
+import type { TablesInsert } from "@/types/supabase";
 import { toKeySlug } from "@/utils/slug";
 import { JSX } from "react/jsx-runtime";
 
@@ -339,7 +341,7 @@ export default function Customers(): JSX.Element {
           const key = toKeySlug(h);
           headerToKey[h] = key;
 
-          const field: CustomField = {
+          const field: TablesInsert<'custom_fields'> = {
             id: uuid(),
             user_id: user.id,
             key,
@@ -348,10 +350,10 @@ export default function Customers(): JSX.Element {
             order: order++,
             options: [],
             required: false,
-            visibleOn: { dashboard: true, customers: true, campaigns: true },
+            visible_on: { dashboard: true, customers: true, campaigns: true },
             archived: false,
           };
-          await addField(field);
+          await supabase.from('custom_fields').insert(field);
         }
       }
 
@@ -436,7 +438,7 @@ export default function Customers(): JSX.Element {
         const key = toKeySlug(k);
         headerToKey[k] = key;
 
-        const field: CustomField = {
+        const field: TablesInsert<'custom_fields'> = {
           id: uuid(),
           user_id: user.id,
           key,
@@ -445,10 +447,10 @@ export default function Customers(): JSX.Element {
           order: order++,
           options: [],
           required: false,
-          visibleOn: { dashboard: true, customers: true, campaigns: true },
+          visible_on: { dashboard: true, customers: true, campaigns: true },
           archived: false,
         };
-        await addField(field);
+        await supabase.from('custom_fields').insert(field);
       }
 
       const mapped: Customer[] = jsonPreview.customers.map((row, idx) => {

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,59 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      custom_fields: {
+        Row: {
+          id: string;
+          user_id: string;
+          key: string;
+          label: string;
+          type: string;
+          options: Json;
+          required: boolean;
+          order: number;
+          visible_on: Json;
+          archived: boolean;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          key: string;
+          label: string;
+          type: string;
+          options?: Json;
+          required?: boolean;
+          order?: number;
+          visible_on?: Json;
+          archived?: boolean;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          key?: string;
+          label?: string;
+          type?: string;
+          options?: Json;
+          required?: boolean;
+          order?: number;
+          visible_on?: Json;
+          archived?: boolean;
+        };
+      };
+    };
+    Views: {};
+    Functions: {};
+    Enums: {};
+    CompositeTypes: {};
+  };
+}
+
+export type TablesInsert<T extends keyof Database['public']['Tables']> =
+  Database['public']['Tables'][T]['Insert'];


### PR DESCRIPTION
## Summary
- use Supabase's generated types for new custom fields
- insert custom fields with proper owner and schema keys
- add stub Supabase types and TODO for regenerating schema

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bf5443e088325b845f949074c598e