### PR TITLE
Scope intake campaign slug validation to current user

### DIFF
--- a/Latest TODO's for Jake
+++ b/Latest TODO's for Jake
@@ -3,6 +3,9 @@
 Keep this file updated after every code change with any manual steps, placeholder values, or pending integrations.
 Whenever the database schema changes, update SUPABASE_SCHEMA_SPEC.txt in tandem and document the required actions here.
 
+### Intake Campaign Slug Validation
+- [INFO] Slug uniqueness check now scoped to the current user in the UI, matching database constraint `(owner_id, slug)`. No manual action required.
+
 ### IntakeRenderer footer button
 - [INFO] No manual deployment steps required. Rebuild and verify sticky submit button on mobile devices.
 

--- a/src/pages/campaigns/intake/New.tsx
+++ b/src/pages/campaigns/intake/New.tsx
@@ -103,14 +103,18 @@ export default function NewIntakeCampaign() {
 
   useEffect(() => {
     if (!slug) return;
-    supabase
-      .from("intake_campaigns")
-      .select("id")
-      .eq("slug", slug)
-      .maybeSingle()
-      .then(({ data }) => {
-        setSlugTaken(!!data && data.id !== campaignId);
-      });
+    void (async () => {
+      const { data: userData } = await supabase.auth.getUser();
+      const userId = userData.user?.id;
+      if (!userId) return;
+      const { data } = await supabase
+        .from("intake_campaigns")
+        .select("id")
+        .eq("slug", slug)
+        .eq("owner_id", userId)
+        .maybeSingle();
+      setSlugTaken(!!data && data.id !== campaignId);
+    })();
   }, [slug, campaignId]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure intake campaign slug uniqueness check is scoped to the current user
- document slug validation behavior in project TODO list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a894d5affc83258ff2daa6c4fcd708